### PR TITLE
[FEATURE] Toggle for page and content template registration

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,5 @@
+  # cat=basic/enable; type=boolean; label=Disable Page Templates: Use this option to completely disable (cannot be selected, cannot be rendered, overlayed, etc) the page templates provided by this extension.
+disablePageTemplates = 0
+
+  # cat=basic/enable; type=boolean; label=Disable Content Templates: Use this option to completely disable (cannot be selected, cannot be rendered, overlayed, etc) the content templates provided by this extension.
+disableContentTemplates = 0

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,8 +3,14 @@ if (!defined('TYPO3_MODE')) {
     die ('Access denied.');
 }
 
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidbootstraptheme']['setup'] = unserialize($_EXTCONF);
+
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Bootstrap Theme');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript/Settings', 'Bootstrap Theme settings');
 
-\FluidTYPO3\Flux\Core::registerProviderExtensionKey('FluidBT.Fluidbootstraptheme', 'Page');
-\FluidTYPO3\Flux\Core::registerProviderExtensionKey('FluidBT.Fluidbootstraptheme', 'Content');
+if (FALSE === (boolean) $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidbootstraptheme']['setup']['disablePageTemplates']) {
+	\FluidTYPO3\Flux\Core::registerProviderExtensionKey('FluidBT.Fluidbootstraptheme', 'Page');
+}
+if (FALSE === (boolean) $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidbootstraptheme']['setup']['disableContentTemplates']) {
+	\FluidTYPO3\Flux\Core::registerProviderExtensionKey('FluidBT.Fluidbootstraptheme', 'Content');
+}


### PR DESCRIPTION
This toggle is added as an extension manager setting which when _enabled_, will _disable_ the corresponding template category.

The reason for not reversing this logic is the assumption that the primary use case for the extension is to use both content and page templates.
