### PR TITLE
[TASK] Add TYPO3 6.2 travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
 
 env:
   - DB=mysql TYPO3=master INTEGRATION=master
+  - DB=mysql TYPO3=TYPO3_6-2 INTEGRATION=master
   - DB=mysql TYPO3=TYPO3_6-1 INTEGRATION=master
 
 matrix:
@@ -12,6 +13,8 @@ matrix:
    include:
      - php: 5.5
        env: DB=mysql TYPO3=master INTEGRATION=master
+     - php: 5.6
+       env: DB=mysql TYPO3=TYPO3_6-2 INTEGRATION=master
 
 before_script:
   - cd ..


### PR DESCRIPTION
master is now TYPO3 6.3

6.2 branch is missing - Task is in forge
http://forge.typo3.org/issues/59645
