### PR TITLE
Added namespaces to Layout "WithSideBar.html"

### DIFF
--- a/Resources/Private/Layouts/WithSideBar.html
+++ b/Resources/Private/Layouts/WithSideBar.html
@@ -1,3 +1,8 @@
+<div xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	 xmlns:v="http://typo3.org/ns/FluidTYPO3/Vhs/ViewHelpers"
+	 xmlns:flux="http://typo3.org/ns/FluidTYPO3/Flux/ViewHelpers"
+	 xmlns:f="http://typo3.org/ns/fluid/ViewHelpers">
+
 <f:layout name="WithSideBar" />
 
 <f:render section="Navigation" partial="Navigation" arguments="{_all}" />
@@ -12,4 +17,6 @@
 	</div>
 	<!--TYPO3SEARCH_end-->
 	<f:render section="Footer" partial="Footer" arguments="{_all}" />
+</div>
+
 </div>


### PR DESCRIPTION
When checking with builder extension this Layout fails with the following exception:
#1224254792: Namespace could not be resolved. This exception should never be thrown! (More information)

With the declared namespaces the builder extension test run works again.
