### PR TITLE
[Bugfix] Third column has 2nd column class

### DIFF
--- a/Resources/Private/Templates/Content/ThreeColumn.html
+++ b/Resources/Private/Templates/Content/ThreeColumn.html
@@ -87,7 +87,7 @@
 		<div class="row {settings.grid3.rowCSS} ">
 			<f:if condition="{settings.grid3.split}=='more'">
 				<f:then>
-					<f:render section="FEMoreGrid2" arguments="{_all}"/>
+					<f:render section="FEMoreGrid3" arguments="{_all}"/>
 				</f:then>
 				<f:else>
 					<f:render section="FE{settings.grid3.split}"
@@ -98,14 +98,14 @@
 	</f:section>
 
 	<f:comment>Frontend Switchcase Sections</f:comment>
-	<f:section name="FEMoreGrid2">
+	<f:section name="FEMoreGrid3">
 		<div class="{settings.grid3.col1width} {settings.grid3.col1CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col1hide, then: 'hidden-xs')}">
 			<flux:content.render area="column1"/>
 		</div>
 		<div class="{settings.grid3.col2width} {settings.grid3.col2CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col2hide, then: 'hidden-xs')}">
 			<flux:content.render area="column2"/>
 		</div>
-		<div class="{settings.grid3.col2width} {settings.grid3.col3CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col2hide, then: 'hidden-xs')}">
+		<div class="{settings.grid3.col3width} {settings.grid3.col3CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col3hide, then: 'hidden-xs')}">
 			<flux:content.render area="column3"/>
 		</div>
 	</f:section>
@@ -116,7 +116,7 @@
 		<div class="col-sm-4 {settings.grid3.col2CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col2hide, then: 'hidden-xs')}">
 			<flux:content.render area="column2"/>
 		</div>
-		<div class="col-sm-4 {settings.grid3.col3CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col2hide, then: 'hidden-xs')}">
+		<div class="col-sm-4 {settings.grid3.col3CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col3hide, then: 'hidden-xs')}">
 			<flux:content.render area="column3"/>
 		</div>
 	</f:section>
@@ -127,7 +127,7 @@
 		<div class="col-sm-6 {settings.grid3.col2CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col2hide, then: 'hidden-xs')}">
 			<flux:content.render area="column2"/>
 		</div>
-		<div class="col-sm-3 {settings.grid3.col3CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col2hide, then: 'hidden-xs')}">
+		<div class="col-sm-3 {settings.grid3.col3CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col3hide, then: 'hidden-xs')}">
 			<flux:content.render area="column3"/>
 		</div>
 	</f:section>
@@ -138,7 +138,7 @@
 		<div class="col-sm-3 {settings.grid3.col2CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col2hide, then: 'hidden-xs')}">
 			<flux:content.render area="column2"/>
 		</div>
-		<div class="col-sm-6 {settings.grid3.col3CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col2hide, then: 'hidden-xs')}">
+		<div class="col-sm-6 {settings.grid3.col3CSS} {f:if(condition: settings.grid3.eqh, then: 'equal-height')} {f:if(condition: settings.grid3.col3hide, then: 'hidden-xs')}">
 			<flux:content.render area="column3"/>
 		</div>
 	</f:section>


### PR DESCRIPTION
In content template ThreeColumn.html:
The third column had the identical class that the second column was assigned to. Mainly a copy & paste error where not all occurences of the number 2 were changed to 3.
