### PR TITLE
[BIGFIX] Change start parameter

### DIFF
--- a/Resources/Private/Templates/Content/Row.html
+++ b/Resources/Private/Templates/Content/Row.html
@@ -22,7 +22,7 @@
 				<flux:grid.row>
 					<v:condition.type.isArray value="{columns}">
 						<f:for each="{columns}" as="sectionObject" iteration="iteration">
-							<v:variable.set name="width" value="{sectionObject.column.class -> v:format.substring(start: 4)}" />
+							<v:variable.set name="width" value="{sectionObject.column.class -> v:format.substring(start: 7)}" />
 							<v:variable.set name="percent" value="{width  -> v:math.division(b: numberOfColumns) -> v:math.product(b: 100) -> v:math.round(decimals: 2)}" />
 							<flux:grid.column style="width: {percent}%" name="column{iteration.cycle}" label="{percent}%" />
 						</f:for>


### PR DESCRIPTION
{sectionObject.column.class} is e.g. 'col-md-6'. For getting only col digit (here: 6) v:format.substring must start after the seventh character.
