### PR TITLE
[BUGFIX] Unable to set search page by page configuration

### DIFF
--- a/Resources/Private/Templates/Page/FrontPage.html
+++ b/Resources/Private/Templates/Page/FrontPage.html
@@ -13,7 +13,7 @@
 										   eval="int,trim" minimum="0" maximum="6" default="{settings.menu.main.entryLevel}">
 				</flux:field.input>
 				<flux:field.checkbox name="settings.enableSearch" default="1" />
-				<flux:field.relation size="1" minItems="0" table="pages" maxItems="1" name="searchPageUid">
+				<flux:field.relation size="1" minItems="0" table="pages" maxItems="1" name="settings.searchPageUid">
 					<flux:wizard.list table="pages" />
 				</flux:field.relation>
 				<flux:field.input name="settings.searchFieldName" />

--- a/Resources/Private/Templates/Page/Render.html
+++ b/Resources/Private/Templates/Page/Render.html
@@ -13,7 +13,7 @@
 								  eval="int,trim" minimum="0" maximum="6" default="{settings.menu.main.entryLevel}">
 				</flux:field.input>
 				<flux:field.checkbox name="settings.enableSearch" default="1" />
-				<flux:field.relation size="1" minItems="0" table="pages" maxItems="1" name="searchPageUid">
+				<flux:field.relation size="1" minItems="0" table="pages" maxItems="1" name="settings.searchPageUid">
 					<flux:wizard.list table="pages" />
 				</flux:field.relation>
 				<flux:field.input name="settings.searchFieldName" label="Name (HTML attribute) of form field, example tx_solr[q]" default="q" />

--- a/Resources/Private/Templates/Page/WithSidebar.html
+++ b/Resources/Private/Templates/Page/WithSidebar.html
@@ -15,7 +15,7 @@
 				</flux:field.input>
 				<flux:field.select name="settings.position" items="left,right" />
 				<flux:field.checkbox name="settings.enableSearch" default="1" />
-				<flux:field.relation size="1" minItems="0" table="pages" maxItems="1" name="searchPageUid">
+				<flux:field.relation size="1" minItems="0" table="pages" maxItems="1" name="settings.searchPageUid">
 					<flux:wizard.list table="pages" />
 				</flux:field.relation>
 				<flux:field.input name="settings.searchFieldName" default="q" />


### PR DESCRIPTION
I am using default page template from this extension and I tried to set search page from page property but it does not work for me. I found that settings. prefix missing. Please disregard my pull-request if the bug has been fixed.

Cheers,
Sengchheang
