### PR TITLE
[TASK] Refactor Travis settings for development branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,12 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
 
 env:
-  - DB=mysql TYPO3=master INTEGRATION=master
-  - DB=mysql TYPO3=TYPO3_6-1 INTEGRATION=master
-
-matrix:
-   fast_finish: true
-   include:
-     - php: 5.6
-       env: DB=mysql TYPO3=master INTEGRATION=master
+  - DB=mysql TYPO3=TYPO3_6-1 INTEGRATION=master BUILDER=master INTRODUCTION=TYPO3_6-1
+  - DB=mysql TYPO3=TYPO3_6-2 INTEGRATION=master BUILDER=master INTRODUCTION=master
+  - DB=mysql TYPO3=master INTEGRATION=master BUILDER=master INTRODUCTION=master
 
 before_script:
   - cd ..
@@ -21,7 +17,7 @@ before_script:
   - git clone git://github.com/squizlabs/PHP_CodeSniffer.git build-environment/CodeSniffer
   - git clone --single-branch --branch $TYPO3 --depth 1 https://github.com/TYPO3/TYPO3.CMS.git core
   - source build-environment/install-helper.sh
-  - git clone --single-branch --branch $TYPO3 --depth 1 git://git.typo3.org/TYPO3CMS/Distributions/Introduction.git build-environment/Introduction
+  - git clone --single-branch --branch $INTRODUCTION --depth 1 git://git.typo3.org/TYPO3CMS/Distributions/Introduction.git build-environment/Introduction
   - mv core/typo3 .
   - if [[ -d core/t3lib ]]; then mv core/t3lib . ; fi
   - mv build-environment/typo3conf .
@@ -29,12 +25,16 @@ before_script:
   - mkdir uploads
   - mkdir typo3temp
 
-  - git clone --depth 1 --single-branch --branch $TRAVIS_BRANCH git://github.com/FluidTYPO3/flux.git typo3conf/ext/flux
-  - git clone --depth 1 --single-branch --branch $TRAVIS_BRANCH git://github.com/FluidTYPO3/fluidcontent.git typo3conf/ext/fluidcontent
-  - git clone --depth 1 --single-branch --branch $TRAVIS_BRANCH git://github.com/FluidTYPO3/fluidpages.git typo3conf/ext/fluidpages
-  - git clone --depth 1 --single-branch --branch $TRAVIS_BRANCH git://github.com/FluidTYPO3/builder.git typo3conf/ext/builder
+  - cp fluidbootstraptheme/composer.json .
+  - composer install
+  - git clone --depth 1 --single-branch --branch $BUILDER git://github.com/FluidTYPO3/builder.git typo3conf/ext/builder
   - git clone --depth 1 git://git.typo3.org/TYPO3CMS/Extensions/phpunit.git typo3conf/ext/phpunit
-  - mv fluidbootstraptheme ./typo3conf/ext/
+  - ln -s ../../vendor/fluidtypo3/flux typo3conf/ext/flux
+  - ln -s ../../vendor/fluidtypo3/fluidcontent typo3conf/ext/fluidcontent
+  - ln -s ../../vendor/fluidtypo3/fluidpages typo3conf/ext/fluidpages
+  - ln -s ../../vendor/fluidtypo3/vhs typo3conf/ext/vhs
+
+  - ln -s ../../fluidbootstraptheme typo3conf/ext/fluidbootstraptheme
 
   - if [[ "$DB" == "mysql" ]]; then mysql -e "DROP DATABASE IF EXISTS typo3_test;" -uroot; fi
   - if [[ "$DB" == "mysql" ]]; then mysql -e "create database IF NOT EXISTS typo3_test;" -uroot; fi
@@ -43,6 +43,8 @@ before_script:
   # post core schema import of extension schemas and state file from this and dependency extensions
   - if [[ "$DB" == "mysql" && -f typo3conf/ext/builder/Build/ImportSchema.sql ]]; then mysql -uroot typo3_test < typo3conf/ext/builder/Build/ImportSchema.sql; fi
   - if [[ "$DB" == "mysql" && -f typo3conf/ext/flux/Build/ImportSchema.sql ]]; then mysql -uroot typo3_test < typo3conf/ext/flux/Build/ImportSchema.sql; fi
+  - if [[ "$DB" == "mysql" && -f typo3conf/ext/fluidpages/Build/ImportSchema.sql ]]; then mysql -uroot typo3_test < typo3conf/ext/fluidpages/Build/ImportSchema.sql; fi
+  - if [[ "$DB" == "mysql" && -f typo3conf/ext/fluidcontent/Build/ImportSchema.sql ]]; then mysql -uroot typo3_test < typo3conf/ext/fluidcontent/Build/ImportSchema.sql; fi
   - if [[ "$DB" == "mysql" && -f typo3conf/ext/fluidbootstraptheme/Build/ImportSchema.sql ]]; then mysql -uroot typo3_test < typo3conf/ext/fluidbootstraptheme/Build/ImportSchema.sql; fi
   - if [[ -f typo3conf/LocalConfiguration.php && -f typo3conf/ext/fluidbootstraptheme/Build/LocalConfiguration.php ]]; then cp typo3conf/ext/fluidbootstraptheme/Build/LocalConfiguration.php typo3conf/LocalConfiguration.php; fi
   - if [[ -f typo3conf/ext/fluidbootstraptheme/Build/PackageStates.php ]]; then cp typo3conf/ext/fluidbootstraptheme/Build/PackageStates.php typo3conf/PackageStates.php; fi


### PR DESCRIPTION
- based on master
- only difference is that we're able to build with TYPO3.CMS master, because we're using all the development branches of FluidTYPO3 especially flux in this case, which failed before
