### PR TITLE
[BUGFIX] Fix "well" handling in columns

### DIFF
--- a/Resources/Private/Templates/Content/Row.html
+++ b/Resources/Private/Templates/Content/Row.html
@@ -35,8 +35,17 @@
 	<f:section name="Main">
 		<div class="row">
 			<f:for each="{columns}" as="sectionObject" iteration="iteration">
-				<div class="{sectionObject.column.class} {sectionObject.column.additionalClass} {f:if(then: 'well', else: '', condition: '{sectionObject.column.addWell}')}">
-					<flux:content.render area="column{iteration.cycle}" />
+				<div class="{sectionObject.column.class} {sectionObject.column.additionalClass}">
+					 <f:if condition='{sectionObject.column.addWell}'>
+					 	<f:then>
+					 		<div class="well">	
+					 			<flux:content.render area="column{iteration.cycle}" />
+				 			</div>
+					 	</f:then>
+					 	<f:else>
+					 		<flux:content.render area="column{iteration.cycle}" />
+					 	</f:else>
+					 </f:if>
 				</div>
 			</f:for>
 		</div>


### PR DESCRIPTION
Due to the padding a well adds/changes to the surrounding div in BS3 a well HAS to be nested inside a column, so it is no good idea to add the well to the existing col-md-XX classes. It is better to add another div inside that column row. Doing it this way, the padding for the row remains correct.
