### PR TITLE
Mention incompatibility with fluidcontent_core template

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ content elements, much like the Flexible Content Elements concept from TemplaVoi
 
 ## How to install it?
 
-Download, install the extension and include the static TypoScript template in your Roottemplate.
+Download, install the extension and include the static TypoScript template in your Roottemplate. The included templates must be at least:
+
+* CSS Styled Content (css_styled_content)
+* Bootstrap Theme (fluidbootstraptheme)
+* Bootstrap Theme Settings (fluidbootstraptheme)
+
+The template ``Fluid Styled Content (fluidcontent_core)`` must **not** be included, or it would output nothing at all in frontend for all FluidBootstrapTheme elements.
+
 You can use the Constant-Editor to define basic configuration for the extension like Columnwidth etc. If you dont want to use the Constant-Editor to set these globally, you can disable this funktionality by adding `plugin.tx_fluidbootstraptheme.settings.useTypoScript = 0` to your Setup. By doing this, you enable these settings in the properties of each page. 
 
 ===


### PR DESCRIPTION
If ``fluidcontent_core`` template is included, then the output in frontend is broken, showing nothing at all for all element coming from FluidBootstrapTheme. Same goes for css_styled_content, which **must** be present in order to see something.