### PR TITLE
[TASK] Switch to new *RootPaths configuration

### DIFF
--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -1,5 +1,5 @@
 plugin.tx_fluidbootstraptheme.view {
-	templateRootPath = EXT:fluidbootstraptheme/Resources/Private/Templates/
-	partialRootPath = EXT:fluidbootstraptheme/Resources/Private/Partials/
-	layoutRootPath = EXT:fluidbootstraptheme/Resources/Private/Layouts/
+	templateRootPaths.0 = EXT:fluidbootstraptheme/Resources/Private/Templates/
+	partialRootPaths.0 = EXT:fluidbootstraptheme/Resources/Private/Partials/
+	layoutRootPaths.0 = EXT:fluidbootstraptheme/Resources/Private/Layouts/
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,11 +1,11 @@
 [GLOBAL]
 plugin.tx_fluidbootstraptheme.view {
-	templateRootPath = {$plugin.tx_fluidbootstraptheme.view.templateRootPath}
-	partialRootPath = {$plugin.tx_fluidbootstraptheme.view.partialRootPath}
-	layoutRootPath = {$plugin.tx_fluidbootstraptheme.view.layoutRootPath}
+	templateRootPaths.0 = {$plugin.tx_fluidbootstraptheme.view.templateRootPaths.0}
+	partialRootPaths.0 = {$plugin.tx_fluidbootstraptheme.view.partialRootPaths.0}
+	layoutRootPaths.0 = {$plugin.tx_fluidbootstraptheme.view.layoutRootPaths.0}
 	widget {
-    		Tx_Fluid_ViewHelpers_Widget_PaginateViewHelper.templateRootPath < plugin.tx_fluidbootstraptheme.view.templateRootPath
-    		TYPO3\CMS\Fluid\ViewHelpers\Widget\PaginateViewHelper.templateRootPath < plugin.tx_fluidbootstraptheme.view.templateRootPath
+    		Tx_Fluid_ViewHelpers_Widget_PaginateViewHelper.templateRootPaths.0 < plugin.tx_fluidbootstraptheme.view.templateRootPaths.0
+    		TYPO3\CMS\Fluid\ViewHelpers\Widget\PaginateViewHelper.templateRootPaths.0 < plugin.tx_fluidbootstraptheme.view.templateRootPaths.0
 	}
 }
 


### PR DESCRIPTION
This allows for much easier overlaying in a provider extensions.  Also this allows us to add "overlay" template much easier in our provider extension and templateRootPath is actually deprecated as far as I understand it and will likely be dropped in TYPO3 CMS 7.2.
